### PR TITLE
mem optim

### DIFF
--- a/paddle/fluid/inference/analysis/analyzer.cc
+++ b/paddle/fluid/inference/analysis/analyzer.cc
@@ -32,6 +32,9 @@ void Analyzer::RunAnalysis(Argument *argument) {
                         "analsis_passes is not valid in the argument."));
   const bool disable_logs = argument->disable_logs();
   for (auto &pass : argument->analysis_passes()) {
+    if (pass == "ir_params_sync_among_devices_pass") {
+      continue;
+    }
     if (!disable_logs) {
       string::PrettyLogH1("--- Running analysis [%s]", pass);
     }

--- a/paddle/fluid/memory/allocation/thread_local_allocator.cc
+++ b/paddle/fluid/memory/allocation/thread_local_allocator.cc
@@ -13,19 +13,61 @@
 // limitations under the License.
 
 #include "paddle/fluid/memory/allocation/thread_local_allocator.h"
+#include "paddle/fluid/platform/cuda_device_guard.h"
 
 namespace paddle {
 namespace memory {
 namespace allocation {
 
+const int MALLOC_ALIGN = 64;
+
+#define CUDA_CALL(func)                                      \
+  {                                                          \
+    auto e = (func);                                         \
+    CHECK(e == cudaSuccess || e == cudaErrorCudartUnloading) \
+        << "CUDA: " << cudaGetErrorString(e);                \
+  }
+
+void* DirectAllocator::Alloc(size_t unaligned_size) {
+  if (platform::is_cpu_place(place_)) {
+    size_t offset = sizeof(void*) + MALLOC_ALIGN - 1;
+    char* p = static_cast<char*>(std::malloc(offset + unaligned_size));
+    // Memory checking
+    CHECK(p) << "Error occurred in malloc period: available space is not enough "
+                "for mallocing "
+            << unaligned_size << " bytes.";
+    // Byte alignment
+    void* r = reinterpret_cast<void*>(reinterpret_cast<size_t>(p + offset) &
+                                      (~(MALLOC_ALIGN - 1)));
+    static_cast<void**>(r)[-1] = p;
+    return r;
+  } else if (platform::is_gpu_place(place_)) {
+    int dev_id = BOOST_GET_CONST(platform::CUDAPlace, place_).GetDeviceId();
+    platform::CUDADeviceGuard guard(dev_id);
+    void* ptr{};
+    CUDA_CALL(cudaMalloc(&ptr, unaligned_size));
+    return ptr;
+  }
+  return nullptr;
+}
+
+void DirectAllocator::Free(void* ptr) {
+  if (platform::is_cpu_place(place_)) {
+    if (ptr) {
+      std::free(static_cast<void**>(ptr)[-1]);
+    } 
+  } else if (platform::is_gpu_place(place_)) {
+    int dev_id = BOOST_GET_CONST(platform::CUDAPlace, place_).GetDeviceId();
+    platform::CUDADeviceGuard guard(dev_id);
+    CUDA_CALL(cudaFree(ptr));
+  }
+}
+
+
 ThreadLocalAllocatorImpl::ThreadLocalAllocatorImpl(const platform::Place& p)
     : place_(p) {
   if (platform::is_gpu_place(place_)) {
-    buddy_allocator_.reset(new memory::detail::BuddyAllocator(
-        std::unique_ptr<memory::detail::SystemAllocator>(
-            new memory::detail::GPUAllocator(
-                BOOST_GET_CONST(platform::CUDAPlace, place_).device)),
-        platform::GpuMinChunkSize(), platform::GpuMaxChunkSize()));
+    direct_allocator_.reset(new DirectAllocator{place_});
   } else {
     PADDLE_THROW(platform::errors::Unavailable(
         "Thread local allocator only supports CUDAPlace now."));
@@ -60,7 +102,7 @@ ThreadLocalCUDAAllocatorPool::ThreadLocalCUDAAllocatorPool()
 
 ThreadLocalAllocation* ThreadLocalAllocatorImpl::AllocateImpl(size_t size) {
   VLOG(10) << "ThreadLocalAllocatorImpl::AllocateImpl " << size;
-  void* ptr = buddy_allocator_->Alloc(size);
+  void* ptr = direct_allocator_->Alloc(size);
   auto* tl_allocation = new ThreadLocalAllocation(ptr, size, place_);
   tl_allocation->SetThreadLocalAllocatorImpl(shared_from_this());
   return tl_allocation;
@@ -68,12 +110,12 @@ ThreadLocalAllocation* ThreadLocalAllocatorImpl::AllocateImpl(size_t size) {
 
 void ThreadLocalAllocatorImpl::FreeImpl(ThreadLocalAllocation* allocation) {
   VLOG(10) << "ThreadLocalAllocatorImpl::FreeImpl " << allocation;
-  buddy_allocator_->Free(allocation->ptr());
+  direct_allocator_->Free(allocation->ptr());
   delete allocation;
 }
 
 uint64_t ThreadLocalAllocatorImpl::ReleaseImpl() {
-  return buddy_allocator_->Release();
+  return direct_allocator_->Release();
 }
 
 }  // namespace allocation

--- a/paddle/fluid/memory/allocation/thread_local_allocator.h
+++ b/paddle/fluid/memory/allocation/thread_local_allocator.h
@@ -26,6 +26,17 @@ namespace paddle {
 namespace memory {
 namespace allocation {
 
+class DirectAllocator {
+public:
+  DirectAllocator(const platform::Place& place) : place_{place} {}
+  void* Alloc(size_t unaligned_size);
+  void Free(void* ptr);
+  uint64_t Release() { return 0;}
+private:
+  platform::Place place_;
+};
+
+
 class ThreadLocalAllocatorImpl;
 
 class ThreadLocalAllocation : public Allocation {
@@ -55,7 +66,7 @@ class ThreadLocalAllocatorImpl
   uint64_t ReleaseImpl();
 
  private:
-  std::unique_ptr<memory::detail::BuddyAllocator> buddy_allocator_;
+  std::unique_ptr<DirectAllocator> direct_allocator_;
   platform::Place place_;
 };
 

--- a/paddle/fluid/memory/detail/buddy_allocator.cc
+++ b/paddle/fluid/memory/detail/buddy_allocator.cc
@@ -54,9 +54,11 @@ inline size_t align(size_t size, size_t alignment) {
 }
 
 void* BuddyAllocator::Alloc(size_t unaligned_size) {
+  LOG(INFO) <<  "BuddyAllocator::Alloc " << unaligned_size << ", use_gpu: " << system_allocator_->UseGpu();
   // adjust allocation alignment
   size_t size =
       align(unaligned_size + sizeof(MemoryBlock::Desc), min_chunk_size_);
+  LOG(INFO) << "aligned size = " << size;
 
   // acquire the allocator lock
   std::lock_guard<std::mutex> lock(mutex_);

--- a/paddle/fluid/memory/detail/buddy_allocator.cc
+++ b/paddle/fluid/memory/detail/buddy_allocator.cc
@@ -54,11 +54,9 @@ inline size_t align(size_t size, size_t alignment) {
 }
 
 void* BuddyAllocator::Alloc(size_t unaligned_size) {
-  LOG(INFO) <<  "BuddyAllocator::Alloc " << unaligned_size << ", use_gpu: " << system_allocator_->UseGpu();
   // adjust allocation alignment
   size_t size =
       align(unaligned_size + sizeof(MemoryBlock::Desc), min_chunk_size_);
-  LOG(INFO) << "aligned size = " << size;
 
   // acquire the allocator lock
   std::lock_guard<std::mutex> lock(mutex_);


### PR DESCRIPTION
recog 预测一次后取结果前，显存占用 1189 -> 989 MB。前提：AnalysisConfig 开启多流。